### PR TITLE
fix setup.sh fail

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "hidapi"]
 	path = hidapi
-	url = git@github.com:signal11/hidapi.git
+	url = git@github.com:libusb/hidapi.git

--- a/steps/build_hidapi.sh
+++ b/steps/build_hidapi.sh
@@ -3,7 +3,10 @@ set -eu -o pipefail
 
 trap "echo ❌ Failed to build HIDAPI" ERR
 
+CONFIG_FILE="configure.ac"
 cd hidapi
+awk '!seen[$0]++ || $0 != "AC_CONFIG_MACRO_DIR([m4])"' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
+echo "✔️ Successfully patched configure.ac"
 ./bootstrap || ./bootstrap # It installs ltmain.sh in the wrong place the first time, then it copies into the right folder the second time...
 ./configure
 make

--- a/steps/build_hidapi.sh
+++ b/steps/build_hidapi.sh
@@ -3,12 +3,9 @@ set -eu -o pipefail
 
 trap "echo ❌ Failed to build HIDAPI" ERR
 
-CONFIG_FILE="configure.ac"
 cd hidapi
-awk '!seen[$0]++ || $0 != "AC_CONFIG_MACRO_DIR([m4])"' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
-echo "✔️ Successfully patched configure.ac"
 ./bootstrap || ./bootstrap # It installs ltmain.sh in the wrong place the first time, then it copies into the right folder the second time...
-./configure
+./configure --with-libusb
 make
 cd ..
 

--- a/steps/build_libmsp430.sh
+++ b/steps/build_libmsp430.sh
@@ -8,7 +8,7 @@ cp hidapi/libusb/hid.o mspds/ThirdParty/lib/hid-libusb.o
 cp hidapi/libusb/hid.o mspds/ThirdParty/lib64/hid-libusb.o
 
 cd mspds
-make STATIC=1
+make
 
 sudo cp libmsp430.so /usr/lib/libmsp430.so
 

--- a/steps/install_apt_packages.sh
+++ b/steps/install_apt_packages.sh
@@ -3,6 +3,6 @@ set -eu -o pipefail
 
 trap "echo ❌ Failed to install APT packages" ERR
 
-DEBIAN_FRONTEND=noninteractive sudo apt-get install -y libboost1.67-all-dev libusb-1.0 libudev-dev mspdebug
+DEBIAN_FRONTEND=noninteractive sudo apt-get install -y libboost1.74-all-dev libusb-1.0 libudev-dev mspdebug
 
 echo ✔️ Successfully installed APT packages


### PR DESCRIPTION
libboost version is updated to libboost1.74-all-dev 
build mspds without STATIC option
update configure.ac of hidapi to make it buildable on raspberry